### PR TITLE
refactor: use PatchConfig and optimize module loading

### DIFF
--- a/patch-loader/src/main/java/org/lsposed/lspatch/service/RemoteApplicationService.java
+++ b/patch-loader/src/main/java/org/lsposed/lspatch/service/RemoteApplicationService.java
@@ -14,7 +14,6 @@ import android.os.ParcelFileDescriptor;
 import android.os.RemoteException;
 import android.os.UserHandle;
 import android.util.Log;
-import android.widget.Toast;
 
 import org.lsposed.lspatch.share.Constants;
 import org.lsposed.lspd.models.Module;
@@ -48,7 +47,7 @@ public class RemoteApplicationService implements ILSPApplicationService {
                 @Override
                 public void onServiceConnected(ComponentName name, IBinder binder) {
                     Log.i(TAG, "Manager binder received");
-                    service = Stub.asInterface(binder);
+                    service = ILSPApplicationService.Stub.asInterface(binder);
                     latch.countDown();
                 }
 
@@ -76,7 +75,6 @@ public class RemoteApplicationService implements ILSPApplicationService {
             if (!success) throw new TimeoutException("Bind service timeout");
         } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException |
                  InterruptedException | TimeoutException e) {
-            Toast.makeText(context, "Unable to connect to Manager", Toast.LENGTH_SHORT).show();
             var r = new RemoteException("Failed to get manager binder");
             r.initCause(e);
             throw r;


### PR DESCRIPTION
重構 LSPApplication，將 config 由 JSONObject 換成 PatchConfig 類 (by Hicores)

feat: Local mode runs without background manager

當應用啟動時，優先嘗試通過 RemoteApplicationService 連接到後台運行的管理器，如果成功，它會從管理器取得最新的模組清單，並將此清單儲存在本地的 SharedPreferences 中。 如果連接失敗，就使用 LocalApplicationService 並按照模組清單來載入模組配置