### PR TITLE
refactor: improve service binding and null safety

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,25 +111,27 @@ jobs:
           -Dorg.gradle.jvmargs=-Xmx3g \
           -Dandroid.native.buildOutput=verbose
 
+    - name: Upload Debug artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: npatch-debug
+        path: out/debug/*
+
     - name: Upload Release artifact
       uses: actions/upload-artifact@v4
       with:
         name: npatch-release
         path: |
           out/release/*
-          patch-loader/build/outputs/aar/* - name: Upload mappings
+          patch-loader/build/outputs/aar/*
+
+    - name: Upload mappings
       uses: actions/upload-artifact@v4
       with:
         name: mappings
         path: |
           patch-loader/build/outputs/mapping
           manager/build/outputs/mapping
-          
-    - name: Upload Debug artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: npatch-debug
-        path: out/debug/*
 
     - name: Upload symbols
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,8 +43,9 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ~/.ccache
-        key: ${{ runner.os }}-ccache-${{ hashFiles('**/src/**/*.cpp', '**/src/**/*.h', '**/CMakeLists.txt') }}
+        key: ${{ runner.os }}-ccache-java-21-adopt-ninja-1.12.0-${{ hashFiles('**/src/**/*.cpp', '**/src/**/*.h', '**/CMakeLists.txt') }}
         restore-keys: |
+          ${{ runner.os }}-ccache-java-21-adopt-ninja-1.12.0-
           ${{ runner.os }}-ccache-
 
     - name: Write signing key if needed
@@ -59,14 +60,14 @@ jobs:
         fi
 
     - name: Checkout libxposed/api
-      uses: actions/checkout@main
+      uses: actions/checkout@v4
       with:
         repository: libxposed/api
         path: libxposed/api
         ref: 54582730315ba4a3d7cfaf9baf9d23c419e07006
 
     - name: Checkout libxposed/service
-      uses: actions/checkout@main
+      uses: actions/checkout@v4
       with:
         repository: libxposed/service
         path: libxposed/service
@@ -105,30 +106,30 @@ jobs:
 
     - name: Build with Gradle
       run: |
-        echo 'org.gradle.parallel=true' >> gradle.properties
-        echo 'org.gradle.jvmargs=-Xmx3g' >> gradle.properties
-        echo 'android.native.buildOutput=verbose' >> gradle.properties
-        ./gradlew buildAll
-
-    - name: Upload Debug artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: npatch-debug
-        path: out/debug/*
+        ./gradlew buildAll \
+          -Dorg.gradle.parallel=true \
+          -Dorg.gradle.jvmargs=-Xmx3g \
+          -Dandroid.native.buildOutput=verbose
 
     - name: Upload Release artifact
       uses: actions/upload-artifact@v4
       with:
         name: npatch-release
-        path: out/release/*
-
-    - name: Upload mappings
+        path: |
+          out/release/*
+          patch-loader/build/outputs/aar/* - name: Upload mappings
       uses: actions/upload-artifact@v4
       with:
         name: mappings
         path: |
           patch-loader/build/outputs/mapping
           manager/build/outputs/mapping
+          
+    - name: Upload Debug artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: npatch-debug
+        path: out/debug/*
 
     - name: Upload symbols
       uses: actions/upload-artifact@v4

--- a/patch-loader/build.gradle.kts
+++ b/patch-loader/build.gradle.kts
@@ -30,16 +30,13 @@ android {
     namespace = "org.lsposed.lspatch.loader"
 }
 
-val assembleReleaseTaskProvider = tasks.named("assembleReleaseAar")
+val assembleReleaseTaskProvider = tasks.named("assembleRelease")
 
 androidComponents.onVariants { variant ->
     val variantCapped = variant.name.replaceFirstChar { it.uppercase(Locale.ROOT) }
     val projectDir = rootProject.layout.projectDirectory
 
-    val assembleVariantTask = when (variant.name) {
-        "release" -> tasks.named("assembleReleaseAar")
-        else -> tasks.named("assemble$variantCapped")
-    }
+    val assembleVariantTask = tasks.named("assemble$variantCapped")
 
     val copyDexTask = tasks.register<Copy>("copyDex$variantCapped") {
         dependsOn(assembleVariantTask)

--- a/patch-loader/src/main/java/org/lsposed/lspatch/service/NeoLocalApplicationService.java
+++ b/patch-loader/src/main/java/org/lsposed/lspatch/service/NeoLocalApplicationService.java
@@ -65,7 +65,7 @@ public class NeoLocalApplicationService extends ILSPApplicationService.Stub {
 
     @Override
     public String getPrefsPath(String packageName) throws RemoteException {
-        return new File(Environment.getDataDirectory(), "data/" + packageName + "/shared_prefs/").getAbsolutePath();
+        return new File(Environment.getDataDirectory(), "data" + File.separator + packageName + File.separator + "shared_prefs").getAbsolutePath();
     }
 
     @Override

--- a/patch/src/main/java/org/lsposed/patch/LSPatch.java
+++ b/patch/src/main/java/org/lsposed/patch/LSPatch.java
@@ -157,7 +157,7 @@ public class LSPatch {
             outputDir.mkdirs();
 
             File outputFile = new File(outputDir, String.format(
-                    Locale.getDefault(), "%s-%d-lspatched.apk",
+                    Locale.getDefault(), "%s-%d-npatched.apk",
                     FilenameUtils.getBaseName(apkFileName),
                     LSPConfig.instance.VERSION_CODE)
             ).getAbsoluteFile();

--- a/share/java/src/main/java/org/lsposed/lspatch/share/Constants.java
+++ b/share/java/src/main/java/org/lsposed/lspatch/share/Constants.java
@@ -8,7 +8,7 @@ public class Constants {
     final static public String ORIGINAL_APK_ASSET_PATH = "assets/lspatch/origin.apk";
     final static public String EMBEDDED_MODULES_ASSET_PATH = "assets/lspatch/modules/";
 
-    final static public String PATCH_FILE_SUFFIX = "-lspatched.apk";
+    final static public String PATCH_FILE_SUFFIX = "-npatched.apk";
     final static public String PROXY_APP_COMPONENT_FACTORY = "org.lsposed.lspatch.metaloader.LSPAppComponentFactoryStub";
     final static public String MANAGER_PACKAGE_NAME = "org.lsposed.npatch";
     final static public int MIN_ROLLING_VERSION_CODE = 348;


### PR DESCRIPTION
getPrefsPath 統一使用 File.separator 以提升兼容性。優化 RemoteApplicationService 的綁定流程，API 29+ 使用官方 bindService，API<29 用反射並封裝到 bindServicePreQ，增加超時和異常處理。