### PR TITLE
Fix Telegram link missing url scheme in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Rootless implementation of LSPosed framework, integrating Xposed API by inserting dex and so into the target APK.
 
-We sincerely invite you to join our [Telegram](t.me/NPatch) group to get more information and updates about NPatch.
+We sincerely invite you to join our [Telegram](https://t.me/NPatch) group to get more information and updates about NPatch.
 
 ## Supported Versions
 


### PR DESCRIPTION
The url link to the telegram channel in [README.md](https://github.com/7723mod/NPatch/blob/master/README.md) is missing the url scheme, making it point to `https://github.com/7723mod/NPatch/blob/master/t.me/NPatch`.