### PR TITLE
Manifest permission corruption fix

### DIFF
--- a/patch/src/main/java/org/lsposed/patch/NPatch.java
+++ b/patch/src/main/java/org/lsposed/patch/NPatch.java
@@ -458,8 +458,9 @@ public class NPatch {
                     return permission.replaceFirst(originPackage, newPackage);
                 }
                 if (permission.startsWith("android")
-                        || permission.startsWith("com.android")){
-                    return permission;
+                || permission.startsWith("com.android")
+                || permission.startsWith("com.google.android")) {
+                return permission;
                 }
                 return newPackage + "_" + permission;
             }


### PR DESCRIPTION
Except
com.google.android.gms.permission.AD_ID
com.google.android.c2dm.permission.RECEIVE
com.google.android.providers.gsf.permission.READ_GSERVICES

Maybe Fix #25 

Before
newPackage_com.google.android.gms.permission.AD_ID
newPackage_com.google.android.c2dm.permission.RECEIVE
newPackage_com.google.android.providers.gsf.permission.READ_GSERVICES
