### PR TITLE
add manifest modification skip logic with keyword matching

### DIFF
--- a/manager/src/main/java/org/lsposed/npatch/Patcher.kt
+++ b/manager/src/main/java/org/lsposed/npatch/Patcher.kt
@@ -16,12 +16,14 @@ import java.io.IOException
 object Patcher {
 
     class Options(
+
         val newPackageName: String,
-        private val injectDex: Boolean,
-        private val config: PatchConfig,
-        private val apkPaths: List<String>,
-        private val embeddedModules: List<String>?
-    ) {
+        val injectDex: Boolean,
+        val config: PatchConfig,
+        val apkPaths: List<String>,
+        val embeddedModules: List<String>?,
+        val skipManifestEntries: String,
+  ) {
         fun toStringArray(): Array<String> {
             return buildList {
                 add("-o"); add(lspApp.tmpApkDir.absolutePath)
@@ -34,8 +36,11 @@ object Patcher {
                 embeddedModules?.forEach {
                     add("-m"); add(it)
                 }
+                if (skipManifestEntries.isNotEmpty()) {
+                    add("--skip-manifest"); add(skipManifestEntries)
+                }
                 if (config.injectProvider) add("--provider")
-                if(injectDex) add("--injectdex")
+                if (injectDex) add("--injectdex")
                 if (!MyKeyStore.useDefault) {
                     addAll(arrayOf("-k", MyKeyStore.file.path, Configs.keyStorePassword, Configs.keyStoreAlias, Configs.keyStoreAliasPassword))
                 }
@@ -43,10 +48,9 @@ object Patcher {
             }.toTypedArray()
         }
     }
-
     suspend fun patch(logger: Logger, options: Options) {
         withContext(Dispatchers.IO) {
-            NPatch(logger, *options.toStringArray()).doCommandLine()
+          NPatch(logger, *options.toStringArray()).doCommandLine()
 
             val uri = Configs.storageDirectory?.toUri()
                 ?: throw IOException("Uri is null")

--- a/manager/src/main/java/org/lsposed/npatch/ui/page/NewPatchScreen.kt
+++ b/manager/src/main/java/org/lsposed/npatch/ui/page/NewPatchScreen.kt
@@ -335,6 +335,14 @@ private fun PatchOptionsBody(modifier: Modifier, onAddEmbed: () -> Unit) {
                 viewModel.newPackageName = it
             },
         )
+        SettingsEditor(
+            modifier = Modifier.padding(top = 6.dp),
+          stringResource(R.string.patch_skip_manifest_entries),
+        viewModel.skipManifestEntries,
+             onValueChange = {
+                viewModel.skipManifestEntries = it
+            },
+        )
         SettingsCheckBox(
             modifier = Modifier
                 .padding(top = 6.dp)

--- a/manager/src/main/java/org/lsposed/npatch/ui/viewmodel/NewPatchViewModel.kt
+++ b/manager/src/main/java/org/lsposed/npatch/ui/viewmodel/NewPatchViewModel.kt
@@ -41,6 +41,7 @@ class NewPatchViewModel : ViewModel() {
     // Patch Configuration
     var useManager by mutableStateOf(true)
     var newPackageName by mutableStateOf("")
+    var skipManifestEntries by mutableStateOf("")
     var debuggable by mutableStateOf(false)
     var overrideVersionCode by mutableStateOf(false)
     var sigBypassLevel by mutableStateOf(2)
@@ -99,17 +100,30 @@ class NewPatchViewModel : ViewModel() {
     private fun submitPatch() {
         Log.d(TAG, "Submit Patch")
         if (useManager) embeddedModules = emptyList()
-        val config = PatchConfig(useManager, debuggable, overrideVersionCode, sigBypassLevel, null, null, injectProvider, outputLog, newPackageName)
+        val config = PatchConfig(
+            useManager,
+            debuggable,
+            overrideVersionCode,
+            sigBypassLevel,
+            null,
+            null,
+            injectProvider,
+            outputLog,
+            newPackageName,
+            skipManifestEntries
+        )
+
+
         patchOptions = Patcher.Options(
             newPackageName = newPackageName,
             injectDex = injectDex,
             config = config,
             apkPaths = listOf(patchApp.app.sourceDir) + (patchApp.app.splitSourceDirs ?: emptyArray()),
-            embeddedModules = embeddedModules.flatMap { listOf(it.app.sourceDir) + (it.app.splitSourceDirs ?: emptyArray()) }
+            embeddedModules = embeddedModules.flatMap { listOf(it.app.sourceDir) + (it.app.splitSourceDirs ?: emptyArray()) },
+            skipManifestEntries = skipManifestEntries
         )
         patchState = PatchState.PATCHING
     }
-
     private suspend fun launchPatch() {
         logger.i("Launch Patch")
         patchState = try {

--- a/manager/src/main/java/org/lsposed/npatch/ui/viewmodel/manage/AppManageViewModel.kt
+++ b/manager/src/main/java/org/lsposed/npatch/ui/viewmodel/manage/AppManageViewModel.kt
@@ -161,7 +161,7 @@ class AppManageViewModel : ViewModel() {
                         }
                     }
                 }
-                Patcher.patch(logger, Patcher.Options(appInfo.app.packageName, false, config, patchPaths, embeddedModulePaths))
+                Patcher.patch(logger, Patcher.Options(appInfo.app.packageName, false, config, patchPaths, embeddedModulePaths,config.skipManifestEntries))
                 if (!ShizukuApi.isPermissionGranted) {
                     val apkFiles = lspApp.targetApkFiles
                     if (apkFiles.isNullOrEmpty()){

--- a/manager/src/main/res/values/strings.xml
+++ b/manager/src/main/res/values/strings.xml
@@ -105,4 +105,5 @@
     <string name="miui_uninstall_title">💩卸💩载💩金💩凡💩</string>
     <string name="miui_uninstall_content">金凡祭天，法力无边\n所以這就是那個魔改到連使用者列表都無法訪問的系統嗎?
     \n\n(我們專門為小米手機桌面解除安裝添加了提示，提升使用者體驗)</string>
+    <string name="patch_skip_manifest_entries">Skip AndroidManifest Tag</string>
 </resources>

--- a/patch-loader/src/main/java/org/lsposed/npatch/loader/LSPApplication.java
+++ b/patch-loader/src/main/java/org/lsposed/npatch/loader/LSPApplication.java
@@ -246,7 +246,9 @@ public class LSPApplication {
                     context.getClassLoader().loadClass(config.appComponentFactory);
                 } catch (Throwable e) {
                     Log.w(TAG, "Original AppComponentFactory not found: " + config.appComponentFactory, e);
-                    appInfo.appComponentFactory = null;
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                        appInfo.appComponentFactory = null;
+                    }
                 }
             }
             Log.i(TAG, "createLoadedApkWithContext cost: " + (System.currentTimeMillis() - timeStart) + "ms");

--- a/patch-loader/src/main/java/org/lsposed/npatch/loader/LSPApplication.java
+++ b/patch-loader/src/main/java/org/lsposed/npatch/loader/LSPApplication.java
@@ -242,11 +242,12 @@ public class LSPApplication {
 
             var context = (Context) XposedHelpers.callStaticMethod(Class.forName("android.app.ContextImpl"), "createAppContext", activityThread, stubLoadedApk);
             if (config.appComponentFactory != null) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
                 try {
                     context.getClassLoader().loadClass(config.appComponentFactory);
                 } catch (Throwable e) {
                     Log.w(TAG, "Original AppComponentFactory not found: " + config.appComponentFactory, e);
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+
                         appInfo.appComponentFactory = null;
                     }
                 }

--- a/patch-loader/src/main/java/org/lsposed/npatch/loader/LSPApplication.java
+++ b/patch-loader/src/main/java/org/lsposed/npatch/loader/LSPApplication.java
@@ -123,7 +123,7 @@ public class LSPApplication {
         disableProfile(context);
         Startup.initXposed(false, ActivityThread.currentProcessName(), context.getApplicationInfo().dataDir, service);
         Startup.bootstrapXposed();
-        
+
         // WARN: Since it uses `XResource`, the following class should not be initialized
         // before forkPostCommon is invoke. Otherwise, you will get failure of XResources
 
@@ -242,12 +242,11 @@ public class LSPApplication {
 
             var context = (Context) XposedHelpers.callStaticMethod(Class.forName("android.app.ContextImpl"), "createAppContext", activityThread, stubLoadedApk);
             if (config.appComponentFactory != null) {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
                 try {
                     context.getClassLoader().loadClass(config.appComponentFactory);
                 } catch (Throwable e) {
                     Log.w(TAG, "Original AppComponentFactory not found: " + config.appComponentFactory, e);
-
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
                         appInfo.appComponentFactory = null;
                     }
                 }

--- a/patch/src/main/java/org/lsposed/patch/NPatch.java
+++ b/patch/src/main/java/org/lsposed/patch/NPatch.java
@@ -453,17 +453,32 @@ public class NPatch {
         property.setPermissionMapper(new PermissionMapper() {
             @Override
             public String map(PermissionType type, String permission) {
-                if (permission.startsWith(originPackage)){
-                    assert newPackage != null;
-                    return permission.replaceFirst(originPackage, newPackage);
-                }
-                if (permission.startsWith("android")
-                        || permission.startsWith("com.android")){
+                if (permission == null || permission.isEmpty()) {
                     return permission;
                 }
+                if (permission.startsWith(originPackage)) {
+                    return permission.replaceFirst(originPackage, newPackage);
+                }
+
+                if (
+                        permission.startsWith("android.") ||
+                                permission.startsWith("com.android.") ||
+                                permission.startsWith("com.google.android.") ||
+                                permission.startsWith("com.google.firebase.") ||
+                                permission.startsWith("com.huawei.") ||
+                                permission.startsWith("com.sonymobile.")
+                ) {
+                    return permission;
+                }
+
+                if (type == PermissionType.USES_PERMISSION) {
+                    return permission;
+                }
+
                 return newPackage + "_" + permission;
             }
         });
+
         property.setAuthorityMapper(new AttributeMapper<String>() {
             @Override
             public String map(String value) {

--- a/patch/src/main/java/org/lsposed/patch/NPatch.java
+++ b/patch/src/main/java/org/lsposed/patch/NPatch.java
@@ -51,6 +51,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class NPatch {
@@ -109,6 +110,9 @@ public class NPatch {
 
     @Parameter(names = {"-m", "--embed"}, description = "Embed provided modules to apk")
     private List<String> modules = new ArrayList<>();
+
+    @Parameter(names = {"--skip-manifest"}, description = "Skip specific manifest modification items (comma separated)")
+    private String skipManifestEntries = "";
 
     private String packageName;
 
@@ -282,10 +286,33 @@ public class NPatch {
 
             logger.i("Patching apk...");
             // modify manifest
-            final var config = new PatchConfig(useManager, debuggableFlag, overrideVersionCode, sigbypassLevel, originalSignature, appComponentFactory, isInjectProvider, outputLog, newPackage);
+            final var config = new PatchConfig(
+                    useManager,
+                    debuggableFlag,
+                    overrideVersionCode,
+                    sigbypassLevel,
+                    originalSignature,
+                    appComponentFactory,
+                    isInjectProvider,
+                    outputLog,
+                    newPackage,
+                    skipManifestEntries
+            );
+
             final var configBytes = new Gson().toJson(config).getBytes(StandardCharsets.UTF_8);
             final var metadata = Base64.getEncoder().encodeToString(configBytes);
-            try (var is = new ByteArrayInputStream(modifyManifestFile(manifestEntry.open(), metadata, minSdkVersion, pair.packageName, newPackage, pair.permissions, pair.use_permissions, pair.authorities))) {
+
+           try (var is = new ByteArrayInputStream(modifyManifestFile(
+                    manifestEntry.open(),
+                    metadata,
+                    minSdkVersion,
+                    pair.packageName,
+                    newPackage,
+                    pair.permissions,
+                    pair.use_permissions,
+                    pair.authorities,
+                    skipManifestEntries
+            ))) {
                 dstZFile.add(ANDROID_MANIFEST_XML, is);
             } catch (Throwable e) {
                 throw new PatchError("Error when modifying manifest", e);
@@ -353,7 +380,6 @@ public class NPatch {
 
             // create zip link
             logger.d("Creating nested apk link...");
-
             for (StoredEntry entry : srcZFile.entries()) {
                 String name = entry.getCentralDirectoryHeader().getName();
                 if (dstZFile.get(name) != null) continue;
@@ -369,7 +395,6 @@ public class NPatch {
         }
         logger.i("Done. Output APK: " + outputFile.getAbsolutePath());
     }
-
     private List<String> replacePermissionWithNewPackage(List<String> list, String pkg, String newPackage){
         List<String> res = new LinkedList<>();
         if (list != null && !list.isEmpty()){
@@ -438,9 +463,25 @@ public class NPatch {
         }
     }
 
-    private byte[] modifyManifestFile(InputStream is, String metadata, int minSdkVersion, String originPackage, String newPackage, List<String> permissions, List<String> uses_permissions, List<String> authorities) throws IOException {
+    private byte[] modifyManifestFile(
+            InputStream is,
+            String metadata,
+            int minSdkVersion,
+            String originPackage,
+            String newPackage,
+            List<String> permissions,
+            List<String> uses_permissions,
+            List<String> authorities,
+            String skipManifestEntries
+    ) throws IOException {
         ModificationProperty property = new ModificationProperty();
 
+        Set<String> skipSet = new HashSet<>();
+        if (skipManifestEntries != null && !skipManifestEntries.isEmpty()) {
+            for (String s : skipManifestEntries.split(",")) {
+                skipSet.add(s.trim().toLowerCase());
+            }
+        }
         if (overrideVersionCode)
             property.addManifestAttribute(new AttributeItem(NodeValue.Manifest.VERSION_CODE, 1));
         if (minSdkVersion < 28)
@@ -450,14 +491,29 @@ public class NPatch {
         if (newPackage != null && !newPackage.isEmpty()){
             property.addManifestAttribute(new AttributeItem(NodeValue.Manifest.PACKAGE, newPackage).setNamespace(null));
         }
-        property.setPermissionMapper(new PermissionMapper() {
+    property.setPermissionMapper(new PermissionMapper() {
             @Override
             public String map(PermissionType type, String permission) {
-                if (permission == null || permission.isEmpty()) {
+                if (permission == null || permission.isEmpty()) return permission;
+                String lowerPermission = permission.toLowerCase();
+                for (String skipItem : skipSet) {
+                    if (lowerPermission.contains(skipItem)) {
+                        logger.i("[Skip] Tag: " + type + " | Name: " + permission + " (Match keyword: " + skipItem + ")");
+                        return permission;
+                    }
+                }
+                if (skipSet.contains("permissions") || skipSet.contains("uses-permission") || skipSet.contains(lowerPermission)) {
+                    logger.i("[Skip] Tag: " + type + " | Name: " + permission + " (Explicitly skipped)");
                     return permission;
                 }
+                String result = permission;
                 if (permission.startsWith(originPackage)) {
-                    return permission.replaceFirst(originPackage, newPackage);
+                    result = permission.replaceFirst(originPackage, newPackage);
+                } else if (type != PermissionType.USES_PERMISSION) {
+                    result = newPackage + "_" + permission;
+                }
+                if (!permission.equals(result)) {
+                    logger.i("[Modify] Tag: " + type + " | " + permission + " -> " + result);
                 }
 
                 if (
@@ -482,6 +538,15 @@ public class NPatch {
         property.setAuthorityMapper(new AttributeMapper<String>() {
             @Override
             public String map(String value) {
+                if (value == null) return null;
+                if (skipSet.contains("authorities") || skipSet.contains("provider")) return value;
+                for (String skipItem : skipSet) {
+                    if (value.toLowerCase().contains(skipItem)) {
+                        logger.i("[Skip] Tag: PROVIDER_AUTHORITY | Name: " + value + " (Keyword match)");
+                        return value;
+                    }
+                }
+                String result;
                 if (value.startsWith(originPackage)){
                     assert newPackage != null;
                     return value.replaceFirst(originPackage, newPackage);
@@ -492,18 +557,18 @@ public class NPatch {
 
         property.addMetaData(new ModificationProperty.MetaData("npatch", metadata));
         // TODO: replace query_all with queries -> manager
-        if (useManager)
+        if (useManager) {
+            logger.i("[Add] Tag: USES_PERMISSION | Name: android.permission.QUERY_ALL_PACKAGES");
             property.addUsesPermission("android.permission.QUERY_ALL_PACKAGES");
-        if (isInjectProvider){
+        }
+        if (isInjectProvider && !skipSet.contains("inject-provider")) {
             HashMap<String,String> providerMap = new HashMap<>();
             providerMap.put("name","bin.mt.file.content.MTDataFilesProvider");
             providerMap.put("permission","android.permission.MANAGE_DOCUMENTS");
             providerMap.put("exported","true");
             providerMap.put("authorities",packageName + ".MTDataFilesProvider");
             providerMap.put("grantUriPermissions","true");
-
             property.addProvider(providerMap,"android.content.action.DOCUMENTS_PROVIDER");
-
         }
 
         var os = new ByteArrayOutputStream();

--- a/share/java/src/main/java/org/lsposed/npatch/share/PatchConfig.java
+++ b/share/java/src/main/java/org/lsposed/npatch/share/PatchConfig.java
@@ -13,6 +13,7 @@ public class PatchConfig {
     public final LSPConfig lspConfig;
     public final String managerPackageName;
     public final String newPackage;
+    public final String skipManifestEntries;
 
     public PatchConfig(
             boolean useManager,
@@ -23,8 +24,8 @@ public class PatchConfig {
             String appComponentFactory,
             boolean injectProvider,
             boolean outputLog,
-            String newPackage
-    ) {
+            String newPackage,
+            String skipManifestEntries) {
         this.useManager = useManager;
         this.debuggable = debuggable;
         this.overrideVersionCode = overrideVersionCode;
@@ -36,5 +37,6 @@ public class PatchConfig {
         this.managerPackageName = Constants.MANAGER_PACKAGE_NAME;
         this.newPackage = newPackage;
         this.outputLog = outputLog;
+        this.skipManifestEntries = skipManifestEntries;
     }
 }


### PR DESCRIPTION
I am developing a module that integrates ReVanced with LSPosed. In this module, manifest permissions are automatically modified; for example, app.google.android.c2dm.permission.RECEIVE is changed to app.revanced.android.c2dm.permission.RECEIVE. To handle this, I have added a feature that allows users to customize  as needed.