### PR TITLE
Prevent redundant authority modification when package names match

### DIFF
--- a/patch/src/main/java/org/lsposed/patch/NPatch.java
+++ b/patch/src/main/java/org/lsposed/patch/NPatch.java
@@ -462,14 +462,17 @@ public class NPatch {
         property.setPermissionMapper(new PermissionMapper() {
             @Override
             public String map(PermissionType type, String permission) {
+                if (originPackage.equals(newPackage)) {
+                    return permission;
+                }
                 if (permission.startsWith(originPackage)){
                     assert newPackage != null;
                     return permission.replaceFirst(originPackage, newPackage);
                 }
                 if (permission.startsWith("android")
-                || permission.startsWith("com.android")
-                || permission.startsWith("com.google.android")) {
-                return permission;
+                        || permission.startsWith("com.android")
+                        || permission.startsWith("com.google.android")) {
+                    return permission;
                 }
                 return newPackage + "_" + permission;
             }
@@ -477,6 +480,9 @@ public class NPatch {
         property.setAuthorityMapper(new AttributeMapper<String>() {
             @Override
             public String map(String value) {
+                if (originPackage.equals(newPackage)) {
+                    return value;
+                }
                 if (value.startsWith(originPackage)){
                     assert newPackage != null;
                     return value.replaceFirst(originPackage, newPackage);


### PR DESCRIPTION
Previously, even if the package name was not being changed, the mapper would append a prefix to any authority that didn't start with the originPackage name. This caused issues with existing providers and internal authorities when the intent was only to modify other manifest attributes without renaming the package.